### PR TITLE
feat: additional unit tests

### DIFF
--- a/granite_core/granite_core/thinking/stream_handler.py
+++ b/granite_core/granite_core/thinking/stream_handler.py
@@ -39,6 +39,8 @@ class ThinkingStreamHandler:
                     self.buffer = self.buffer.split(st, 1)[1]
                     self.current_tag = st
                     yield TagStartEvent(tag=self.tag_names[self.current_tag])
+                    self.lookahead.append(self.buffer)
+                    return
         else:
             self.lookahead.append(token)
             # Build current string from lookahead

--- a/granite_core/tests/test_markdown.py
+++ b/granite_core/tests/test_markdown.py
@@ -1,0 +1,64 @@
+# © Copyright IBM Corporation 2025
+# SPDX-License-Identifier: Apache-2.0
+
+
+import pytest
+
+from granite_core.markdown import get_markdown_sections, get_markdown_tokens_with_content
+
+
+@pytest.mark.asyncio
+async def test_markdown_sectioning() -> None:
+    """Test markdown processing"""
+
+    section_text = [
+        "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",  # noqa: E501
+        "Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
+        "Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.",
+        "Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",  # noqa: E501
+    ]
+
+    markdown_str = f"""
+{section_text[0]}
+
+# Heading
+{section_text[1]}
+
+## Heading
+{section_text[2]}
+
+**bold heading**
+{section_text[3]}
+"""
+
+    extracted_sections = get_markdown_sections(markdown_str)
+    assert len(extracted_sections) == len(section_text)
+    for i in range(len(section_text)):
+        assert extracted_sections[i].content == section_text[i]
+
+
+@pytest.mark.asyncio
+async def test_markdown_tokenization() -> None:
+    """Test inline token extraction"""
+
+    section_text = [
+        "*Lorem* ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",  # noqa: E501
+        "Lorem",
+        "Ipsum",
+        "Dolor",
+    ]
+
+    markdown_text = f"""{section_text[0]}
+- {section_text[1]}
+- {section_text[2]}
+1. {section_text[3]}
+"""
+    tokens = get_markdown_tokens_with_content(markdown_text)
+
+    assert len(tokens) == len(section_text)
+
+    for i in range(len(section_text)):
+        start, end = tokens[i].start_index, tokens[i].end_index
+        print(markdown_text[start:end])
+        print(section_text[i])
+        assert markdown_text[start:end] == section_text[i]

--- a/granite_core/tests/test_memory.py
+++ b/granite_core/tests/test_memory.py
@@ -1,0 +1,17 @@
+# © Copyright IBM Corporation 2025
+# SPDX-License-Identifier: Apache-2.0
+
+
+import pytest
+from beeai_framework.backend import AssistantMessage, Message, UserMessage
+
+from granite_core.memory import estimate_tokens
+
+
+@pytest.mark.asyncio
+async def test_token_estimate() -> None:
+    """Test token count estimation"""
+
+    messages: list[Message] = [UserMessage("Hello!"), AssistantMessage("Hello there! How can I assist you?")]
+
+    assert estimate_tokens(messages) == 15

--- a/granite_core/tests/test_scraper.py
+++ b/granite_core/tests/test_scraper.py
@@ -1,0 +1,20 @@
+# © Copyright IBM Corporation 2025
+# SPDX-License-Identifier: Apache-2.0
+
+
+import pytest
+
+from granite_core.search.scraping import scrape_search_results
+from granite_core.search.types import SearchResult
+
+
+@pytest.mark.asyncio
+async def test_scraper() -> None:
+    """Test scraping infra"""
+    search_result = SearchResult(title="IBM", body="", href="https://www.ibm.com/about")
+
+    results, _ = await scrape_search_results(
+        search_results=[search_result], scraper_key="bs", session_id="", max_scraped_content=1
+    )
+
+    assert len(results) == 1

--- a/granite_core/tests/test_thinking.py
+++ b/granite_core/tests/test_thinking.py
@@ -1,0 +1,78 @@
+# © Copyright IBM Corporation 2025
+# SPDX-License-Identifier: Apache-2.0
+
+
+import pytest
+
+from granite_core.thinking.response_parser import ThinkingResponseParser
+from granite_core.thinking.stream_handler import TagStartEvent, ThinkingStreamHandler, TokenEvent
+
+
+@pytest.mark.asyncio
+async def test_streaming() -> None:
+    """Test thinking stream"""
+
+    thinking_text = "The user asked for me to think. I should think. I will also include a <tag></tag>"
+    response_text = "I am done thinking!"
+
+    stream = f"<think>{thinking_text}</think><response>{response_text}</response>"
+    tokens = [stream[i : i + 4] for i in range(0, len(stream), 4)]
+    handler = ThinkingStreamHandler(tags=["think", "response"])
+
+    thinking: list[str] = []
+    response: list[str] = []
+
+    for token in tokens:
+        for output in handler.on_token(token=token):
+            if isinstance(output, TokenEvent):
+                if output.tag == "think" and output.token:
+                    thinking.append(output.token)
+                elif output.tag == "response" and output.token:
+                    response.append(output.token)
+            elif isinstance(output, TagStartEvent):
+                pass
+
+    assert "".join(thinking) == thinking_text
+    assert "".join(response) == response_text
+
+
+@pytest.mark.asyncio
+async def test_weird_streaming() -> None:
+    """Test thinking stream with noise"""
+
+    thinking_text = "The user asked for me to think. I should think. I will also include a <tag></tag>"
+    response_text = "<response>I am done thinking!"
+
+    stream = f"Random text. <think>{thinking_text}</think><response>{response_text}</response> Random text."
+    tokens = [stream[i : i + 4] for i in range(0, len(stream), 4)]
+    handler = ThinkingStreamHandler(tags=["think", "response"])
+
+    thinking: list[str] = []
+    response: list[str] = []
+
+    for token in tokens:
+        for output in handler.on_token(token=token):
+            if isinstance(output, TokenEvent):
+                if output.tag == "think" and output.token:
+                    thinking.append(output.token)
+                elif output.tag == "response" and output.token:
+                    response.append(output.token)
+            elif isinstance(output, TagStartEvent):
+                pass
+
+    assert "".join(thinking) == thinking_text
+    assert "".join(response) == response_text
+
+
+@pytest.mark.asyncio
+async def test_parsing() -> None:
+    """Test thinking parse"""
+    thinking_text = "The user asked for me to think. I should think. I will also include a <tag></tag>"
+    response_text = "I am done thinking!"
+    stream = f"<think>{thinking_text}</think><response>{response_text}</response>"
+
+    parser = ThinkingResponseParser()
+    response = parser.parse(stream)
+
+    assert response.thinking == thinking_text
+    assert response.response == response_text


### PR DESCRIPTION
### Description

Adds additional unit tests to the test suite.

Includes a fix for the ThinkingStreamHandler that was uncovered by one of the tests.

### Checklist

- [x] I have read and agree to the [contributor guide](https://github.com/ibm-granite-community/granite-playground-agents?tab=contributing-ov-file)
- [x] I have [signed off](https://github.com/ibm-granite-community/granite-playground-agents?tab=contributing-ov-file#developer-certificate-of-origin-1) on my commits
- [x] Commit messages and PR title follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Pre-commit passes
- [ ] Documentation is updated
