### PR TITLE
fix: await can_scape function

### DIFF
--- a/granite_core/granite_core/search/scraping/arxiv.py
+++ b/granite_core/granite_core/search/scraping/arxiv.py
@@ -30,7 +30,7 @@ class ArxivScraper(AsyncScraper):
         for a given query extracted from the link.
         """
 
-        if not self.can_scrape(link):
+        if not await self.can_scrape(link):
             return None
 
         query = link.split("/")[-1]


### PR DESCRIPTION
### Description

can_scape should be awaited, fixes warning from running tests

```
tests/test_arxiv_scraper.py::test_arxix_scrape
  granite_core/granite_core/search/scraping/arxiv.py:33: RuntimeWarning: coroutine 'AsyncScraper.can_scrape' was never awaited
    if not self.can_scrape(link):
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.
```

### Checklist

- [x] I have read and agree to the [contributor guide](https://github.com/ibm-granite-community/granite-playground-agents?tab=contributing-ov-file)
- [x] I have [signed off](https://github.com/ibm-granite-community/granite-playground-agents?tab=contributing-ov-file#developer-certificate-of-origin-1) on my commits
- [x] Commit messages and PR title follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Pre-commit passes
- [ ] Documentation is updated
