### PR TITLE
fix: stored trajectory restoring backwards

### DIFF
--- a/a2a/a2a_agents/trajectory.py
+++ b/a2a/a2a_agents/trajectory.py
@@ -28,7 +28,7 @@ class TrajectoryHandler:
         logger.debug(formatted_log_msg)
         trajectory_metadata = self.trajectory.trajectory_metadata(title=title, content=content)
         await self.context.yield_async(trajectory_metadata)
-        self.log.insert(0, trajectory_metadata)
+        self.log.append(trajectory_metadata)
 
     async def store(self) -> None:
         for metadata in self.log:


### PR DESCRIPTION
### Description

The previous fix we put in place to reverse the trajectory seems to have been undone so I wonder whether Agent Stack has fixed this issue internally in 0.4.2?  This fix restores the more intuitive ordering.

### Checklist

- [x] I have read and agree to the [contributor guide](https://github.com/ibm-granite-community/granite-playground-agents?tab=contributing-ov-file)
- [x] I have [signed off](https://github.com/ibm-granite-community/granite-playground-agents?tab=contributing-ov-file#developer-certificate-of-origin-1) on my commits
- [x] Commit messages and PR title follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Pre-commit passes
- [ ] Documentation is updated
