### PR TITLE
feat: trajectory groups and markdown for search agent

### DIFF
--- a/a2a/a2a_agents/agent_search.py
+++ b/a2a/a2a_agents/agent_search.py
@@ -98,7 +98,7 @@ async def search(
         structured_chat_model = ChatModelFactory.create(model_type="structured")
 
         # trajectory message: search start
-        await trajectory_handler.yield_trajectory(title="Searching the web", content="starting")
+        await trajectory_handler.yield_trajectory(title="Searching the web", content="* Starting", group_id="search")
 
         # run the search
         search_tool = SearchTool(chat_model=structured_chat_model, session_id=context.context_id)
@@ -112,7 +112,9 @@ async def search(
             messages = [SystemMessage(content=ChatPrompts.chat_system_prompt()), *messages]
 
         # trajectory message: search complete
-        await trajectory_handler.yield_trajectory(title="Searching the web", content="complete")
+        await trajectory_handler.yield_trajectory(
+            title="Searching the web", content="* Starting\n* Complete", group_id="search"
+        )
 
         # yield response
         async with chat_pool.throttle():
@@ -126,7 +128,9 @@ async def search(
 
         # Yield citations
         if len(docs) > 0:
-            await trajectory_handler.yield_trajectory(title="Generating citations", content="starting")
+            await trajectory_handler.yield_trajectory(
+                title="Generating citations", content="* Starting", group_id="citations"
+            )
 
             # generate citations
             async def citation_handler(event: Event) -> None:
@@ -147,7 +151,9 @@ async def search(
             generator = CitationGeneratorFactory.create()
             generator.subscribe(handler=citation_handler)
             await generator.generate(docs=docs, response="".join(final_agent_response_text))
-            await trajectory_handler.yield_trajectory(title="Generating citations", content="complete")
+            await trajectory_handler.yield_trajectory(
+                title="Generating citations", content="* Starting\n* Complete", group_id="citations"
+            )
 
         await trajectory_handler.store()
         await context.store(

--- a/a2a/a2a_agents/trajectory.py
+++ b/a2a/a2a_agents/trajectory.py
@@ -20,13 +20,15 @@ class TrajectoryHandler:
         self.context = context
         self.log: list[Metadata[str, Any]] = []
 
-    async def yield_trajectory(self, title: str | None = None, content: str | None = None) -> None:
+    async def yield_trajectory(
+        self, title: str | None = None, content: str | None = None, group_id: str | None = None
+    ) -> None:
         if title is None and content is None:
             return
         log_msg = f"{title}: {content}"
         formatted_log_msg = log_msg[:77] + "..." if len(log_msg) > 77 else log_msg
         logger.debug(formatted_log_msg)
-        trajectory_metadata = self.trajectory.trajectory_metadata(title=title, content=content)
+        trajectory_metadata = self.trajectory.trajectory_metadata(title=title, content=content, group_id=group_id)
         await self.context.yield_async(trajectory_metadata)
         self.log.insert(0, trajectory_metadata)
 

--- a/a2a/pyproject.toml
+++ b/a2a/pyproject.toml
@@ -5,7 +5,7 @@ description = "A2A Granite Chat"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
- "agentstack-sdk>=0.4.0",
+ "agentstack-sdk>=0.4.2",
  "granite-core",
 ]
 

--- a/a2a/uv.lock
+++ b/a2a/uv.lock
@@ -26,7 +26,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "agentstack-sdk", specifier = ">=0.4.0" },
+    { name = "agentstack-sdk", specifier = ">=0.4.2" },
     { name = "granite-core", editable = "../granite_core" },
 ]
 
@@ -66,7 +66,7 @@ wheels = [
 
 [[package]]
 name = "agentstack-sdk"
-version = "0.4.0"
+version = "0.4.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "a2a-sdk" },
@@ -86,9 +86,9 @@ dependencies = [
     { name = "tenacity" },
     { name = "uvicorn" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f5/b5/01a649665e76c2e53106a96f4f82c182776cc6eb2f83944c08233d04e7ad/agentstack_sdk-0.4.0.tar.gz", hash = "sha256:a151931e37909e77019987ab979af0b0faa1e179053e8bdf025eb90860f92212", size = 37795, upload-time = "2025-10-30T16:18:52.379Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/59/57/9a33c7b4f063540e3af34d4171eacfaa426399bd7716a14c0061ee6a8dd1/agentstack_sdk-0.4.3.tar.gz", hash = "sha256:d27fdfe728ddaedcea93db416b022e48a4309a9e11384ae3a962ccd2e9ea0707", size = 42184, upload-time = "2025-12-05T10:20:46.992Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e0/fd/6b2f8c90fee012a066dfc18a712d0742b97c434868be6a3fc2d6ed64a790/agentstack_sdk-0.4.0-py3-none-any.whl", hash = "sha256:247c8235755a86518abd0c056668bb96bfe8549140831f56d9d203ef1cefccc8", size = 67149, upload-time = "2025-10-30T16:18:50.943Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/97/2cc71e013e9d4c378f1b48d99fc3f0f98531cdc477183b2586bc38629f12/agentstack_sdk-0.4.3-py3-none-any.whl", hash = "sha256:ffd45d8a759a8436291f9b140d4299d332ac1ddd988a056f0a2c92af8c93bdfe", size = 76188, upload-time = "2025-12-05T10:20:45.572Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Description

Adds trajectory grouping and markdown formatting to the search agent.

Note: the research agent will need a bit more thinking and work to figure out the implementation and will rely on merging one of the existing open PRs (for fixing ordering) so suggest we merge and update the research agent trajectory separately.

### Checklist

- [x] I have read and agree to the [contributor guide](https://github.com/ibm-granite-community/granite-playground-agents?tab=contributing-ov-file)
- [x] I have [signed off](https://github.com/ibm-granite-community/granite-playground-agents?tab=contributing-ov-file#developer-certificate-of-origin-1) on my commits
- [x] Commit messages and PR title follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Pre-commit passes
- [ ] Documentation is updated
