### PR TITLE
fix: display a2a trajectory lists properly

### DIFF
--- a/a2a/a2a_agents/agent_research.py
+++ b/a2a/a2a_agents/agent_research.py
@@ -105,7 +105,9 @@ async def research(
                 if event.content is None:
                     await trajectory_handler.yield_trajectory(title=event.title)
                 elif isinstance(event.content, str):
-                    await trajectory_handler.yield_trajectory(title=event.title, content=event.content)
+                    await trajectory_handler.yield_trajectory(
+                        title=event.title, content=event.content, group_id=event.title
+                    )
                 elif isinstance(event.content, list):
                     await trajectory_handler.yield_trajectory(
                         title=event.title, content="\n".join(f"* {c}" for c in event.content)
@@ -133,7 +135,7 @@ async def research(
 
             elif isinstance(event, GeneratingCitationsCompleteEvent):
                 await trajectory_handler.yield_trajectory(
-                    title="Generating citations", content="* Starting\n* Complete", group_id="citations"
+                    title="Generating citations", content="Complete", group_id="citations"
                 )
 
         # create and run the researcher

--- a/a2a/a2a_agents/agent_search.py
+++ b/a2a/a2a_agents/agent_search.py
@@ -112,9 +112,7 @@ async def search(
             messages = [SystemMessage(content=ChatPrompts.chat_system_prompt()), *messages]
 
         # trajectory message: search complete
-        await trajectory_handler.yield_trajectory(
-            title="Searching the web", content="* Starting\n* Complete", group_id="search"
-        )
+        await trajectory_handler.yield_trajectory(title="Searching the web", content="Complete", group_id="search")
 
         # yield response
         async with chat_pool.throttle():
@@ -152,7 +150,7 @@ async def search(
             generator.subscribe(handler=citation_handler)
             await generator.generate(docs=docs, response="".join(final_agent_response_text))
             await trajectory_handler.yield_trajectory(
-                title="Generating citations", content="* Starting\n* Complete", group_id="citations"
+                title="Generating citations", content="Complete", group_id="citations"
             )
 
         await trajectory_handler.store()

--- a/a2a/a2a_agents/trajectory.py
+++ b/a2a/a2a_agents/trajectory.py
@@ -28,9 +28,21 @@ class TrajectoryHandler:
         log_msg = f"{title}: {content}"
         formatted_log_msg = log_msg[:77] + "..." if len(log_msg) > 77 else log_msg
         logger.debug(formatted_log_msg)
+
+        # search the log for previous entries with the same group_id and append content
+        if group_id is not None and content is not None:
+            for log_entry in self.log:
+                if log_entry[self.trajectory.spec.URI]["group_id"] == group_id:
+                    logged_content = str(log_entry[self.trajectory.spec.URI]["content"])
+                    if logged_content.startswith("* "):
+                        content = f"{logged_content}\n* {content}"
+                    else:
+                        content = f"* {logged_content}\n* {content}"
+                    break
+
         trajectory_metadata = self.trajectory.trajectory_metadata(title=title, content=content, group_id=group_id)
-        await self.context.yield_async(trajectory_metadata)
         self.log.append(trajectory_metadata)
+        await self.context.yield_async(trajectory_metadata)
 
     async def store(self) -> None:
         for metadata in self.log:


### PR DESCRIPTION
Format lists properly when outputting a2a trajectory from research agent.

### Checklist

- [x] I have read and agree to the [contributor guide](https://github.com/ibm-granite-community/granite-playground-agents?tab=contributing-ov-file)
- [x] I have [signed off](https://github.com/ibm-granite-community/granite-playground-agents?tab=contributing-ov-file#developer-certificate-of-origin-1) on my commits
- [x] Commit messages and PR title follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Pre-commit passes
- [ ] Documentation is updated
