### PR TITLE
fix: update a2a docs and launch json

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,7 +14,7 @@
             "name": "Debug A2A Agent",
             "type": "debugpy",
             "request": "launch",
-            "module": "a2a_agents.agent",
+            "module": "a2a_agents.agents.agent",
             "console": "integratedTerminal",
             "cwd": "${workspaceFolder}/a2a",
             "python": "${workspaceFolder}/a2a/.venv/bin/python"
@@ -23,7 +23,7 @@
             "name": "Debug A2A Chat Agent",
             "type": "debugpy",
             "request": "launch",
-            "module": "a2a_agents.agent_chat",
+            "module": "a2a_agents.agents.chat.agent_chat",
             "console": "integratedTerminal",
             "cwd": "${workspaceFolder}/a2a",
             "python": "${workspaceFolder}/a2a/.venv/bin/python"
@@ -32,7 +32,7 @@
             "name": "Debug A2A Search Agent",
             "type": "debugpy",
             "request": "launch",
-            "module": "a2a_agents.agent_search",
+            "module": "a2a_agents.agents.search.agent_search",
             "console": "integratedTerminal",
             "cwd": "${workspaceFolder}/a2a",
             "python": "${workspaceFolder}/a2a/.venv/bin/python"
@@ -41,7 +41,7 @@
             "name": "Debug A2A Research Agent",
             "type": "debugpy",
             "request": "launch",
-            "module": "a2a_agents.agent_research",
+            "module": "a2a_agents.agents.research.agent_research",
             "console": "integratedTerminal",
             "cwd": "${workspaceFolder}/a2a",
             "python": "${workspaceFolder}/a2a/.venv/bin/python"

--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ Select which agent you would like to run and start the agent:
 # pick one of these
 uv --directory a2a run -m a2a_agents.agents.agent
 uv --directory a2a run -m a2a_agents.agents.chat.agent_chat
-uv --directory a2a run -m a2a_agents.agents.chat.agent_search
-uv --directory a2a run -m a2a_agents.agents.chat.agent_research
+uv --directory a2a run -m a2a_agents.agents.search.agent_search
+uv --directory a2a run -m a2a_agents.agents.research.agent_research
 ```
 
 After starting the agent, you will see lots of log output. If you're running the Agent Stack Platform then the agent will register itself with the platform and you will see the following log message that indicates success:


### PR DESCRIPTION
FIxes some broken paths related to a2a agents.

### Checklist

- [x] I have read and agree to the [contributor guide](https://github.com/ibm-granite-community/granite-playground-agents?tab=contributing-ov-file)
- [x] I have [signed off](https://github.com/ibm-granite-community/granite-playground-agents?tab=contributing-ov-file#developer-certificate-of-origin-1) on my commits
- [x] Commit messages and PR title follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Pre-commit passes
- [x] Documentation is updated
