### PR TITLE
fix: sanitize embeddings

### DIFF
--- a/granite_core/granite_core/search/embeddings/utils.py
+++ b/granite_core/granite_core/search/embeddings/utils.py
@@ -1,0 +1,7 @@
+# © Copyright IBM Corporation 2025
+# SPDX-License-Identifier: Apache-2.0
+
+
+def sanitize_for_embedding(text: str) -> str:
+    # Remove lone backslashes and control chars
+    return text.replace("\\", "\\\\").replace("\x00", "")

--- a/granite_core/granite_core/search/embeddings/watsonx.py
+++ b/granite_core/granite_core/search/embeddings/watsonx.py
@@ -10,6 +10,7 @@ from beeai_framework.backend import EmbeddingModel, EmbeddingModelOutput
 from langchain_core.embeddings import Embeddings
 
 from granite_core.config import settings
+from granite_core.search.embeddings.utils import sanitize_for_embedding
 from granite_core.utils import batch
 from granite_core.work import WorkerPool
 
@@ -31,7 +32,9 @@ class WatsonxEmbeddings(Embeddings):
 
     async def _embed_doc_batch(self, texts: list[str]) -> list[list[float]]:
         async with self.worker_pool.throttle():
-            response: EmbeddingModelOutput = await self.embedding_model.create(texts, max_retries=settings.MAX_RETRIES)
+            response: EmbeddingModelOutput = await self.embedding_model.create(
+                [sanitize_for_embedding(t) for t in texts], max_retries=settings.MAX_RETRIES
+            )
             return response.embeddings
 
     def embed_documents(self, texts: list[str]) -> list[list[float]]:


### PR DESCRIPTION
Samitize embedding text before sending to watsonx.
Remove invalid escapes and control chars. 

```
litellm.exceptions.BadRequestError: litellm.BadRequestError: WatsonxException - {"errors":[{"code":"invalid_input_argument","message":"Invalid input argument for Model 'ibm/slate-125m-english-rtrvr-v2': [{'type': 'json_invalid', 'loc': ('body', 63890), 'msg': 'JSON decode error', 'input': {}, 'ctx': {'error': 'Invalid \\\\escape'}}]","more_info":"https://cloud.ibm.com/apidocs/watsonx-ai#text-embeddings"}],"trace":"54f29a8f37e166d1513497eb374ac40c","status_code":400}
```

### Checklist

- [x] I have read and agree to the [contributor guide](https://github.com/ibm-granite-community/granite-playground-agents?tab=contributing-ov-file)
- [x] I have [signed off](https://github.com/ibm-granite-community/granite-playground-agents?tab=contributing-ov-file#developer-certificate-of-origin-1) on my commits
- [x] Commit messages and PR title follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Pre-commit passes
- [ ] Documentation is updated
