### PR TITLE
fix: relax the copyright guardrail

### DIFF
--- a/granite_core/granite_core/gurardrails/copyright.py
+++ b/granite_core/granite_core/gurardrails/copyright.py
@@ -30,7 +30,8 @@ class CopyrightViolationGuardrail(Guardrail):
 Evaluate the dialog for copyright risk. Pay close attention to the user's last message and decide if the assistant could potentially risk copyright law by answering.
 
 Criteria:
-When evaluating an input, treat it as a copyright risk if the user is requesting long or verbatim reproduction of copyrighted text they have not provided; requests for summaries, analyses, paraphrases, explanations, or short excerpts are allowed. Requests to output substantial portions of modern books, songs, poems, scripts, or other creative works should be flagged, unless the user includes the text themselves. In short: if the user wants you to produce copyrighted text you don’t already have in the prompt, it’s disallowed; if they want you to explain or transform provided text, it’s allowed.
+- When evaluating an input, treat it as a copyright risk if the user is requesting long or verbatim reproduction of copyrighted text they have not provided; requests for summaries, analyses, paraphrases, explanations, or short excerpts are allowed. Requests to output substantial portions of modern books, songs, poems, scripts, or other creative works should be flagged, unless the user includes the text themselves. In short: if the user wants you to produce copyrighted text you don’t already have in the prompt, it’s disallowed; if they want you to explain or transform provided text, it’s allowed.
+- If the user simply states the name of a 3rd party copyrighted work, this is not a copyright risk. Assume the agent will respond with a summary. If the user asks for a summary of a copyrighted work, this is not a copyright risk.
 """  # noqa: E501, RUF001
 
     async def evaluate(self, messages: list[AnyMessage]) -> GuardrailResult:


### PR DESCRIPTION
### Description

Slight clarification to the copyright guardrail to allow users to name a potentially copyrighted work without being guard railed.

For example the prompt `The Model by Kraftwerk` should not be guard railed.

### Checklist

- [x] I have read and agree to the [contributor guide](https://github.com/ibm-granite-community/granite-playground-agents?tab=contributing-ov-file)
- [x] I have [signed off](https://github.com/ibm-granite-community/granite-playground-agents?tab=contributing-ov-file#developer-certificate-of-origin-1) on my commits
- [x] Commit messages and PR title follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Pre-commit passes
- [ ] Documentation is updated
