### PR TITLE
fix: improve data sanitization for embeddings

### DIFF
--- a/granite_core/granite_core/search/embeddings/utils.py
+++ b/granite_core/granite_core/search/embeddings/utils.py
@@ -2,6 +2,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-def sanitize_for_embedding(text: str) -> str:
-    # Remove lone backslashes and control chars
-    return text.replace("\\", "\\\\").replace("\x00", "")
+from contextlib import suppress
+
+
+def sanitize_for_embedding(s: str) -> str:
+    # decode unicode escapes if possible
+    with suppress(UnicodeDecodeError):
+        s = s.encode(encoding="utf-8").decode(encoding="unicode_escape")
+
+    #  remove control characters
+    s = "".join(c for c in s if ord(c) >= 32)
+    return s

--- a/granite_core/granite_core/search/embeddings/watsonx.py
+++ b/granite_core/granite_core/search/embeddings/watsonx.py
@@ -31,9 +31,11 @@ class WatsonxEmbeddings(Embeddings):
         return list(chain.from_iterable(results))
 
     async def _embed_doc_batch(self, texts: list[str]) -> list[list[float]]:
+        safe_texts: list[str] = [sanitize_for_embedding(t) for t in texts]
+
         async with self.worker_pool.throttle():
             response: EmbeddingModelOutput = await self.embedding_model.create(
-                [sanitize_for_embedding(t) for t in texts], max_retries=settings.MAX_RETRIES
+                values=safe_texts, max_retries=settings.MAX_RETRIES
             )
             return response.embeddings
 

--- a/granite_core/tests/test_embeddings.py
+++ b/granite_core/tests/test_embeddings.py
@@ -12,5 +12,16 @@ from granite_core.search.embeddings.model import EmbeddingsModel
 async def test_basic_embeddings() -> None:
     """Test basic embedding infrastructure"""
     embeddings_model: EmbeddingsModel = EmbeddingsFactory.create()
-    vectors = await embeddings_model.embeddings.aembed_documents(["King", "Queen"])
+    vectors: list[list[float]] = await embeddings_model.embeddings.aembed_documents(texts=["King", "Queen"])
     assert vectors and len(vectors) == 2
+
+
+@pytest.mark.asyncio
+async def test_bad_encoding() -> None:
+    """Test embedding strings that are known to cause problems"""
+    embeddings_model: EmbeddingsModel = EmbeddingsFactory.create()
+    bad_texts: list[str] = [
+        'table.compare th{background:#f3f4f6;font-weight:700}\\n#qmeta-collection table.compare tr:last-child td{border-bottom:none}\\n#qmeta-collection .cols{columns:2;gap:28px}\\n@media(max-width:700px){#qmeta-collection .cols{columns:1}}\\n#qmeta-collection details{background:#f9fafb;border:1px solid var(--line);border-radius:14px;padding:10px 12px}\\n#qmeta-collection details+details{margin-top:10px}\\n#qmeta-collection details summary{cursor:pointer;font-weight:700;color:var(--ink)}\\n#qmeta-collection .faq dl{display:grid;grid-template-columns:1fr;gap:10px}\\n#qmeta-collection .faq dt{font-weight:800;color:var(--ink)}\\n#qmeta-collection .faq dt strong{color:var(--ink)}\\n#qmeta-collection .note{font-size:.9rem;color:var(--muted)}\\n#qmeta-collection footer{padding:30px 0;color:var(--muted)}\\n#qmeta-collection code.k{background:#f3f4f6;border:1px solid var(--line);padding:2px 6px;border-radius:6px}\\n\\u003c\\/style\\u003e\\n\\u003cdiv class=\\"wrap\\" id=\\"qmeta-collection\\"\\u003e\\n\\u003c!-- HERO --\\u003e\\u003cheader class=\\"hero\\"\\u003e\\n\\u003cdiv class=\\"kicker\\"\\u003eKEF Q Series Speakers\\u003c\\/div\\u003e\\n\\u003ch2\\u003eKEF Q11, Q7, Q Concerto, Q3, Q1, Q6, Q8 \\u0026amp; Q4 \u2014 Compare \\u0026amp; Shop\\u003c\\/h2\\u003e\\n\\u003cp'  # noqa: E501
+    ]
+    vectors: list[list[float]] = await embeddings_model.embeddings.aembed_documents(texts=bad_texts)
+    assert len(vectors) == len(bad_texts)


### PR DESCRIPTION
Improve data sanitization pior to embedding. Specifically fixes an issue with watsonx embedding backend where json is decoded. 

```[{"code":"invalid_input_argument","message":"Invalid input argument for Model 'ibm/slate-125m-english-rtrvr-v2': [{'type': 'json_invalid', 'loc': ('body', 47752), 'msg': 'JSON decode error', 'input': {}, 'ctx': {'error': 'Invalid \\\\escape'}}]","more_info":"https://cloud.ibm.com/apidocs/watsonx-ai#text-embeddings"}],"trace":"a8ef2c096a75e7a5dbb03c9b986eaad1","status_code":400}```

Included test case.

### Checklist

- [x] I have read and agree to the [contributor guide](https://github.com/ibm-granite-community/granite-playground-agents?tab=contributing-ov-file)
- [x] I have [signed off](https://github.com/ibm-granite-community/granite-playground-agents?tab=contributing-ov-file#developer-certificate-of-origin-1) on my commits
- [x] Commit messages and PR title follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Pre-commit passes
- [ ] Documentation is updated
