### PR TITLE
fix: increase scraper httpx client read timeout

### DIFF
--- a/granite_core/granite_core/search/scraping/runner.py
+++ b/granite_core/granite_core/search/scraping/runner.py
@@ -50,7 +50,7 @@ class ScraperRunner(EventEmitter):
         """
         super().__init__()
         self.urls = urls
-        self.async_client = AsyncClient(timeout=Timeout(connect=5, read=8, write=5, pool=5))
+        self.async_client = AsyncClient(timeout=Timeout(connect=5, read=10, write=5, pool=5))
         self.async_client.headers.update(headers={"User-Agent": UserAgent().user_agent})
         self._counter_lock = asyncio.Lock()
         self._content_count: int = 0


### PR DESCRIPTION
### Description

Bump the scraper https client read timeout. Helps when reading slow sites. 

### Checklist

- [x] I have read and agree to the [contributor guide](https://github.com/ibm-granite-community/granite-playground-agents?tab=contributing-ov-file)
- [x] I have [signed off](https://github.com/ibm-granite-community/granite-playground-agents?tab=contributing-ov-file#developer-certificate-of-origin-1) on my commits
- [x] Commit messages and PR title follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Pre-commit passes
- [ ] Documentation is updated
