### PR TITLE
fix: relax citation similarity threshold

### DIFF
--- a/granite_core/granite_core/config.py
+++ b/granite_core/granite_core/config.py
@@ -211,7 +211,7 @@ class Settings(BaseSettings):
         description="The max. number of source statements per response statement",
     )
     CITATIONS_SIM_THRESHOLD: float = Field(
-        default=0.8,
+        default=0.75,
         description="The similarity threshold under which citation statements are ignored.",
     )
 


### PR DESCRIPTION
Relaxe the citation similarity threshold. This will open up more possibilities for the citation algorithm to cite sources. 

We can also change this via the CITATIONS_SIM_THRESHOLD env variable.

FYI: Test fail is due to bad test case, fixed in #41 

### Checklist

- [x] I have read and agree to the [contributor guide](https://github.com/ibm-granite-community/granite-playground-agents?tab=contributing-ov-file)
- [x] I have [signed off](https://github.com/ibm-granite-community/granite-playground-agents?tab=contributing-ov-file#developer-certificate-of-origin-1) on my commits
- [x] Commit messages and PR title follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Pre-commit passes
- [ ] Documentation is updated
