### PR TITLE
Fix/update scraper test

### DIFF
--- a/granite_core/tests/test_scraper.py
+++ b/granite_core/tests/test_scraper.py
@@ -20,10 +20,11 @@ async def test_scraper() -> None:
 
     assert len(results) == 1
 
+    # Reddit blocks all scrapers
     search_result = SearchResult(
-        title="Instagram",
+        title="Reddit",
         snippet="",
-        url="https://instagram.com/",
+        url="https://reddit.com/",
     )
 
     results = await scrape_search_results(


### PR DESCRIPTION
Updates the scraper test to be more reliable. 

The previous test was failing as expected based on timeout, but timeout changes means that the test sometimes passed. I updated the test so that it was fail on robots.txt rules, rather than timeout.

### Checklist

- [x] I have read and agree to the [contributor guide](https://github.com/ibm-granite-community/granite-playground-agents?tab=contributing-ov-file)
- [x] I have [signed off](https://github.com/ibm-granite-community/granite-playground-agents?tab=contributing-ov-file#developer-certificate-of-origin-1) on my commits
- [x] Commit messages and PR title follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Pre-commit passes
- [ ] Documentation is updated
