### PR TITLE
fix: correct run commands

### DIFF
--- a/granite_core_mcp/README.md
+++ b/granite_core_mcp/README.md
@@ -40,10 +40,10 @@ The Internet Search service provides a tool to search the internet.
 
 ```bash
 # Run with default settings (port 8001, streamable-http transport)
-uv --directory granite_core -m granite_core_mcp.internet_search
+uv --directory granite_core_mcp run -m granite_core_mcp.internet_search
 
 # Run with custom settings
-uv --directory granite_core -m granite_core_mcp.internet_search --transport stdio
+uv --directory granite_core_mcp run -m granite_core_mcp.internet_search --transport stdio
 ```
 
 **Command-line options:**


### PR DESCRIPTION
Fixes incorrect uv commands in the run examples for mcp service. 

### Checklist

- [x] I have read and agree to the [contributor guide](https://github.com/ibm-granite-community/granite-playground-agents?tab=contributing-ov-file)
- [x] I have [signed off](https://github.com/ibm-granite-community/granite-playground-agents?tab=contributing-ov-file#developer-certificate-of-origin-1) on my commits
- [x] Commit messages and PR title follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Pre-commit passes
- [x] Documentation is updated
