### PR TITLE
feat: research topic clarification

### DIFF
--- a/granite_core/granite_core/research/prompts.py
+++ b/granite_core/granite_core/research/prompts.py
@@ -209,3 +209,32 @@ Conversation:
 
 Generate a standalone topic that clearly and concisely reflects the user's intent.
 """  # noqa: E501
+
+    @staticmethod
+    def intent_routing_system_prompt() -> str:
+        return """You are an intent classifier for a research assistant system.
+Analyze the conversation history and determine the user's current intent.
+
+There are two possible intents:
+1. "clarification" - The user is still clarifying, refining, or discussing what topic they want to research. They may be asking questions, providing more details, or exploring different angles before committing to research.
+2. "research" - The user has agreed to proceed with research on a specific topic. This is indicated by explicit agreement (e.g., "yes", "go ahead", "sounds good", "let's do it") or by providing a clear, final research request.
+
+Guidelines:
+- If the user is asking questions, seeking suggestions, or discussing options, choose "clarification"
+- If the user explicitly agrees to proceed or gives a clear go-ahead signal, choose "research"
+- Consider the full conversation context, not just the last message
+
+Determine the intent and provide reasoning for your decision based on the conversation."""  # noqa: E501
+
+    @staticmethod
+    def clarification_system_prompt() -> str:
+        return """You are a helpful research assistant helping users clarify their research topics efficiently.
+
+Your role is to:
+- Quickly understand what the user wants to research
+- Only ask clarifying questions if the topic is genuinely unclear or ambiguous
+- Be concise and direct - avoid unnecessary back-and-forth
+- Suggest a clear research direction and encourage the user to proceed
+- Aim to get to research in as few turns as possible
+
+Keep responses brief and actionable. If the user's intent is reasonably clear, propose a research topic and ask for confirmation to proceed rather than asking more questions."""  # noqa: E501

--- a/granite_core/granite_core/research/prompts.py
+++ b/granite_core/granite_core/research/prompts.py
@@ -228,13 +228,17 @@ Determine the intent and provide reasoning for your decision based on the conver
 
     @staticmethod
     def clarification_system_prompt() -> str:
-        return """You are a helpful research assistant helping users clarify their research topics efficiently.
+        return """You are a enthusiastic research assistant helping users define their research topic.
 
-Your role is to:
-- Quickly understand what the user wants to research
-- Only ask clarifying questions if the topic is genuinely unclear or ambiguous
-- Be concise and direct - avoid unnecessary back-and-forth
-- Suggest a clear research direction and encourage the user to proceed
-- Aim to get to research in as few turns as possible
+Your ONLY goal is to arrive at a research topic and get explicit user confirmation to proceed with a minimum of turns.
 
-Keep responses brief and actionable. If the user's intent is reasonably clear, propose a research topic and ask for confirmation to proceed rather than asking more questions."""  # noqa: E501
+Instructions:
+- The user may just provide a topic as a starting point. If so, ask them if they want to proceed with that topic.
+- If the topic is clear, just clarify the topic with the user and ask if they want to proceed with the research process.
+- If the topic is very unclear: Ask specific questions (ideally only 1) to clarify, then propose a topic.
+- Always give the user the option to proceed with the current topic, even if its vague
+- Do NOT provide information, explanations, or educational content. They may want to research a topic that you dont know about, focus on facilitating.
+- Do NOT engage in extended conversation
+- Keep responses short and concise (no more than 2 sentences)
+
+Your response should lead directly to a yes/no decision to begin research."""  # noqa: E501

--- a/granite_core/granite_core/research/types.py
+++ b/granite_core/granite_core/research/types.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
+from typing import Literal
+
 from pydantic import BaseModel, Field
 
 
@@ -32,3 +34,12 @@ class ResearchTopicSchema(BaseModel):
 
 class LanguageIdentificationSchema(BaseModel):
     language: str = Field(description="The identified language.")
+
+
+class IntentRoutingSchema(BaseModel):
+    intent: Literal["clarification", "research"] = Field(
+        description="The determined intent: 'clarification' if the user is clarifying their topic selection, or 'research' if the user has agreed and research should begin."  # noqa: E501
+    )
+    reasoning: str = Field(
+        description="Brief explanation of why this intent was chosen based on the conversation context."
+    )


### PR DESCRIPTION
Adds Intent-based routing for research agent that determines user intent before research execution:
- Clarification - User refining their topic → streams conversational guidance
- Research - User ready to proceed → executes full research workflow

### Checklist

- [x] I have read and agree to the [contributor guide](https://github.com/ibm-granite-community/granite-playground-agents?tab=contributing-ov-file)
- [x] I have run pre-commit and all checks pass <!-- See README for instructions -->
- [x] Tests written and pass <!-- New code should include tests, code changes should update tests -->
- [ ] Documentation is updated <!-- If this PR does not require documentation updates, please explain why -->
